### PR TITLE
Add S3 bucket name suffix and tagging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ your stack in a different region.
 
 ## Additional Flags
 
+* `--stackit-s3-suffix "random"`
+If the s3 bucket stackit creates requires a unique S3 bucket name.
+
+* `--stackit-tags "key=val,key2=val2"`
+If the s3 bucket stackit creates requires tags, you can add them with this flag.
+
 TODO: Document these properly
 
 * `--service-role VAL`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,8 @@ func init() {
 	RootCmd.PersistentFlags().String("region", "", "")
 	RootCmd.PersistentFlags().String("profile", "", "")
 	RootCmd.PersistentFlags().String("stack-name", "", "")
+	RootCmd.PersistentFlags().String("stackit-s3-suffix", "", "")
+	RootCmd.PersistentFlags().String("stackit-tags", "", "")
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports Persistent Flags, which, if defined here,

--- a/pkg/stackit/packager/packager.go
+++ b/pkg/stackit/packager/packager.go
@@ -5,30 +5,35 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/glassechidna/stackit/pkg/stackit/cfnyaml"
 	"github.com/glassechidna/stackit/pkg/zipper"
 	"github.com/pkg/errors"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type Packager struct {
-	s3     s3iface.S3API
-	sts    stsiface.STSAPI
-	region string
+	s3       s3iface.S3API
+	sts      stsiface.STSAPI
+	region   string
+	s3Suffix string
+	s3Tags   string
 
 	cachedBucketName string
 }
 
-func New(s3 s3iface.S3API, sts stsiface.STSAPI, region string) *Packager {
+func New(s3 s3iface.S3API, sts stsiface.STSAPI, region string, s3Suffix string, s3Tags string) *Packager {
 	return &Packager{
-		s3:     s3,
-		sts:    sts,
-		region: region,
+		s3:       s3,
+		sts:      sts,
+		region:   region,
+		s3Suffix: s3Suffix,
+		s3Tags:   s3Tags,
 	}
 }
 

--- a/pkg/stackit/up.go
+++ b/pkg/stackit/up.go
@@ -3,14 +3,15 @@ package stackit
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/glassechidna/stackit/pkg/stackit/changeset"
 	"github.com/pkg/errors"
-	"strings"
-	"time"
 )
 
 type Template interface {
@@ -28,6 +29,8 @@ type StackitUpInput struct {
 	Tags             map[string]string
 	NotificationARNs []string
 	PopulateMissing  bool
+	S3Suffix         string
+	S3Tags           string
 }
 
 func (s *Stackit) populateMissing(ctx context.Context, input *StackitUpInput) error {


### PR DESCRIPTION
Adding following options to stackit cli.

```
* `--stackit-s3-suffix "random"`
If the s3 bucket stackit creates requires a unique S3 bucket name.

* `--stackit-tags "key=val,key2=val2"`
If the s3 bucket stackit creates requires tags, you can add them with this flag.
```